### PR TITLE
Handle native VLAN without tagging

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -69,6 +69,9 @@ terraform/
    
    # Proxmox node
    proxmox_node = "your-proxmox-node"
+
+    # VLAN used by the Proxmox host (untagged)
+    proxmox_native_vlan = 55
    
    # VM credentials
    vm_user = "your-username"
@@ -214,6 +217,10 @@ vlans = {
   }
 }
 ```
+
+The variable `proxmox_native_vlan` defines which VLAN on `vmbr0` is untagged by
+the Proxmox host. Interfaces assigned to this VLAN will be created without a
+tag to ensure connectivity.
 
 ### IP Address Management
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,7 +11,8 @@ module "vms" {
   disk_size      = var.vm_disk_size
   storage        = var.vm_storage
   network_bridge = "vmbr0"
-  vlan_tag       = var.vlans[each.value.vlan].vlan_id
+  # If the VM uses the same VLAN as the Proxmox host, do not tag the interface
+  vlan_tag       = var.vlans[each.value.vlan].vlan_id == var.proxmox_native_vlan ? 0 : var.vlans[each.value.vlan].vlan_id
   ip_address     = each.value.ip_address
   gateway        = var.vlans[each.value.vlan].gateway
   netmask        = tonumber(split("/", var.vlans[each.value.vlan].subnet)[1])

--- a/terraform/modules/vm/variables.tf
+++ b/terraform/modules/vm/variables.tf
@@ -51,8 +51,9 @@ variable "network_bridge" {
 }
 
 variable "vlan_tag" {
-  description = "VLAN tag"
+  description = "VLAN tag (0 for untagged)"
   type        = number
+  default     = 0
 }
 
 variable "ip_address" {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -6,6 +6,9 @@ proxmox_api_token_secret = "changeme"
 # Proxmox node where VMs will be created
 proxmox_node = "proxmox"
 
+# VLAN used by the Proxmox host (untagged)
+proxmox_native_vlan = 55
+
 # Default VM credentials
 vm_user = "clouduser"
 vm_password = "P@ssw0rd"
@@ -32,5 +35,5 @@ vlans = {
 
 # Assign IP addresses to the test VMs defined in locals.tf
 vm_ip_addresses = {
-servername = "192.168.xx.xx"
+  servername = "192.168.xx.xx"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -54,6 +54,13 @@ variable "vlans" {
   }))
 }
 
+# VLAN ID used untagged by the Proxmox host. VMs on this VLAN will have no tag.
+variable "proxmox_native_vlan" {
+  description = "Proxmox host native VLAN"
+  type        = number
+  default     = 55
+}
+
 # VM Defaults
 variable "vm_cores" {
   description = "Default number of CPU cores"


### PR DESCRIPTION
## Summary
- add `proxmox_native_vlan` variable so hosts on the same VLAN as Proxmox are not tagged
- default `vlan_tag` variable allows untagged (0) traffic
- document new variable in README and example tfvars
- conditionally skip VLAN tag when creating VMs

## Testing
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_6879663ee1c483278d89f024927f0668