### PR TITLE
Enable three-node Docker swarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A comprehensive Infrastructure as Code (IaC) solution for homelab automation usi
 | vm-server-automation | Rundeck automation server | Server (20) | 2 CPU, 2GB RAM |
 | port-o-party-1 | Docker Swarm manager | Server (20) | 4 CPU, 8GB RAM |
 | port-o-party-2 | Docker Swarm worker | Server (20) | 4 CPU, 8GB RAM |
+| port-o-party-3 | Docker Swarm worker | Server (20) | 4 CPU, 8GB RAM |
 | vm-server-minecraft | Minecraft game server | Server (20) | 2 CPU, 2GB RAM |
 | vm-server-wazuh | Security monitoring | Server (20) | 2 CPU, 2GB RAM |
 
@@ -143,7 +144,7 @@ The infrastructure uses VLAN-based network segregation:
 
 ### Docker Swarm Cluster
 - **Manager**: port-o-party-1
-- **Worker**: port-o-party-2
+- **Workers**: port-o-party-2, port-o-party-3
 - **Features**: Automatic cluster formation, shared networking
 
 ### Minecraft Server

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -103,7 +103,7 @@ The dynamic inventory creates the following groups:
 |-------|-----|---------|
 | `all` | All VMs | Global configuration |
 | `automation` | vm-server-automation | Rundeck automation server |
-| `docker` | port-o-party-1, port-o-party-2 | Docker Swarm cluster |
+| `docker` | port-o-party-1, port-o-party-2, port-o-party-3 | Docker Swarm cluster |
 | `minecraft` | vm-server-minecraft | Minecraft game server |
 | `wazuh` | vm-server-wazuh | Security monitoring |
 | `zabbix` | Monitor-o-saurus | Infrastructure monitoring |
@@ -170,7 +170,7 @@ The dynamic inventory creates the following groups:
 
 **Components**:
 - **Manager Node**: port-o-party-1 (first Docker host)
-- **Worker Node**: port-o-party-2 (additional Docker hosts)
+- **Worker Nodes**: port-o-party-2, port-o-party-3
 
 **Key Tasks**:
 ```yaml
@@ -459,6 +459,7 @@ vm-server-minecraft ansible_host=192.168.20.13
 vm-server-wazuh ansible_host=192.168.20.14
 port-o-party-1 ansible_host=192.168.20.11
 port-o-party-2 ansible_host=192.168.20.12
+port-o-party-3 ansible_host=192.168.20.15
 
 [automation]
 vm-server-automation ansible_host=192.168.20.10
@@ -472,6 +473,7 @@ vm-server-wazuh ansible_host=192.168.20.14
 [docker]
 port-o-party-1 ansible_host=192.168.20.11
 port-o-party-2 ansible_host=192.168.20.12
+port-o-party-3 ansible_host=192.168.20.15
 ```
 
 ## 🔧 Usage

--- a/scripts/generate_inventory.sh
+++ b/scripts/generate_inventory.sh
@@ -15,6 +15,7 @@ get_vm_name() {
     "zabbix") echo "Monitor-o-saurus";;
     "docker1") echo "port-o-party-1";;
     "docker2") echo "port-o-party-2";;
+    "docker3") echo "port-o-party-3";;
     *) echo "vm-server-$key";;
   esac
 }

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -94,6 +94,7 @@ terraform/
      automation = "192.168.20.10"
      docker1    = "192.168.20.11"
      docker2    = "192.168.20.12"
+     docker3    = "192.168.20.15"
      minecraft  = "192.168.20.13"
      wazuh      = "192.168.20.14"
    }
@@ -172,6 +173,30 @@ locals {
       cloudinit_file = "cloudinit/ubuntu-cloudinit.yaml"
       description    = "Docker server 1"
     }
+
+    docker2 = {
+      name           = "port-o-party-2"
+      vmid           = 104
+      cores          = 4
+      memory         = 8192
+      vlan           = "server"
+      ip_address     = var.vm_ip_addresses["docker2"]
+      os_type        = "ubuntu"
+      cloudinit_file = "cloudinit/ubuntu-cloudinit.yaml"
+      description    = "Docker server 2"
+    }
+
+    docker3 = {
+      name           = "port-o-party-3"
+      vmid           = 105
+      cores          = 4
+      memory         = 8192
+      vlan           = "server"
+      ip_address     = var.vm_ip_addresses["docker3"]
+      os_type        = "ubuntu"
+      cloudinit_file = "cloudinit/ubuntu-cloudinit.yaml"
+      description    = "Docker server 3"
+    }
     # ... additional VMs
   }
 }
@@ -231,6 +256,7 @@ vm_ip_addresses = {
   automation = "192.168.20.10"
   docker1    = "192.168.20.11"
   docker2    = "192.168.20.12"
+  docker3    = "192.168.20.15"
   minecraft  = "192.168.20.13"
   wazuh      = "192.168.20.14"
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -33,7 +33,12 @@ vlans = {
   }
 }
 
-# Assign IP addresses to the test VMs defined in locals.tf
+# Assign IP addresses to the VMs defined in locals.tf
 vm_ip_addresses = {
-  servername = "192.168.xx.xx"
+  automation = "192.168.20.10"
+  docker1    = "192.168.20.11"
+  docker2    = "192.168.20.12"
+  docker3    = "192.168.20.15"
+  minecraft  = "192.168.20.13"
+  wazuh      = "192.168.20.14"
 }


### PR DESCRIPTION
## Summary
- document third Docker node across READMEs
- map `docker3` hostname in inventory generator
- provide IP examples for the three-node swarm

## Testing
- `apt-get update`
- `apt-get install -y shellcheck`
- `shellcheck scripts/generate_inventory.sh`


------
https://chatgpt.com/codex/tasks/task_e_687aadef0aa48327ab2f71acf9863b7e