### PR TITLE
Add Docker compose stack sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ HomebaseOps/
 │   ├── modules/             # Reusable modules
 │   │   └── vm/              # VM creation module
 │   └── cloudinit/           # Cloud-init templates
+├── compose/                 # Docker Compose stacks
+│   ├── portainer/           # Example stack
+│   │   └── docker-compose.yml
+│   └── whoami/              # Example stack
+│       └── docker-compose.yml
 └── ansible/                 # Configuration management
     ├── README.md            # Ansible-specific documentation
     ├── ansible.cfg          # Ansible configuration
@@ -146,6 +151,7 @@ The infrastructure uses VLAN-based network segregation:
 - **Manager**: port-o-party-1
 - **Workers**: port-o-party-2, port-o-party-3
 - **Features**: Automatic cluster formation, shared networking
+- **Stacks**: Compose files in `compose/` sync to the swarm
 
 ### Minecraft Server
 - **Java Edition**: Latest stable version

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -167,6 +167,7 @@ The dynamic inventory creates the following groups:
 - Docker Swarm cluster configuration
 - Automatic manager/worker node setup
 - Shared networking configuration
+- Auto-deploy compose stacks from `../compose`
 
 **Components**:
 - **Manager Node**: port-o-party-1 (first Docker host)
@@ -754,6 +755,7 @@ ansible-playbook -i inventory.ini playbooks/site.yml --tags "ROLE_NAME"
 
 ### With Services
 - Docker Swarm ready for container deployment
+- Compose files in `../compose` automatically deployed
 - Minecraft server ready for player connections
 - Rundeck ready for job scheduling
 - Wazuh ready for security monitoring

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -86,3 +86,39 @@
       failed_when:
         - join_result.rc != 0
         - "'This node is already part of a swarm' not in join_result.stderr"
+
+    - name: Install python3-pip
+      become: true
+      apt:
+        name: python3-pip
+        state: present
+
+    - name: Install Docker Compose
+      become: true
+      pip:
+        name: docker-compose
+        state: present
+
+    - name: Ensure stack directory exists
+      become: true
+      file:
+        path: /opt/docker-stacks
+        state: directory
+        mode: '0755'
+      when: inventory_hostname == groups['docker'][0]
+
+    - name: Copy docker-compose files to manager
+      become: true
+      copy:
+        src: "{{ item }}"
+        dest: "/opt/docker-stacks/{{ item | dirname | basename }}.yml"
+      with_fileglob:
+        - "{{ playbook_dir }}/../compose/*/docker-compose.yml"
+      when: inventory_hostname == groups['docker'][0]
+
+    - name: Deploy docker stacks
+      become: true
+      shell: docker stack deploy -c /opt/docker-stacks/{{ item | dirname | basename }}.yml {{ item | dirname | basename }}
+      with_fileglob:
+        - "{{ playbook_dir }}/../compose/*/docker-compose.yml"
+      when: inventory_hostname == groups['docker'][0]

--- a/compose/portainer/docker-compose.yml
+++ b/compose/portainer/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+services:
+  portainer:
+    image: portainer/portainer-ce:latest
+    ports:
+      - "9000:9000"
+    volumes:
+      - portainer_data:/data
+      - /var/run/docker.sock:/var/run/docker.sock
+    deploy:
+      placement:
+        constraints: [node.role == manager]
+volumes:
+  portainer_data:

--- a/compose/whoami/docker-compose.yml
+++ b/compose/whoami/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.8"
+services:
+  whoami:
+    image: containous/whoami
+    ports:
+      - "8000:80"
+    deploy:
+      replicas: 2


### PR DESCRIPTION
## Summary
- introduce `compose/` with example Portainer and Whoami stacks
- deploy compose files automatically from Docker role
- update documentation for new directory and behaviour

## Testing
- `apt-get update -y`
- `apt-get install -y ansible`
- `ANSIBLE_CONFIG=ansible/ansible.cfg ansible-playbook ansible/playbooks/site.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_e_687ab12a77d0832789aee539cad7834b